### PR TITLE
Add ride cancellation in backend

### DIFF
--- a/backend/Projekatsiit2023/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/request/RideCancelRequest.java
+++ b/backend/Projekatsiit2023/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/request/RideCancelRequest.java
@@ -1,0 +1,20 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import rs.ac.uns.ftn.asd.Projekatsiit2023.enums.CancelerType;
+
+public class RideCancelRequest {
+
+    private String reason;
+
+    @NotNull(message = "Canceler type is required (DRIVER or PASSENGER)")
+    private CancelerType cancelerType;
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+
+    public CancelerType getCancelerType() { return cancelerType; }
+    public void setCancelerType(CancelerType cancelerType) {
+        this.cancelerType = cancelerType;
+    }
+}

--- a/backend/Projekatsiit2023/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/RideCancelResponse.java
+++ b/backend/Projekatsiit2023/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/RideCancelResponse.java
@@ -1,0 +1,19 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response;
+
+import rs.ac.uns.ftn.asd.Projekatsiit2023.enums.CancelerType;
+
+public class RideCancelResponse {
+    private boolean success = true;
+    private CancelerType cancelledBy;
+    private String reason;
+
+    public RideCancelResponse(boolean success, CancelerType cancelledBy, String reason) {
+        this.success = success;
+        this.cancelledBy = cancelledBy;
+        this.reason = reason;
+    }
+
+    public boolean isSuccess() { return success; }
+    public CancelerType getCancelledBy() { return cancelledBy; }
+    public String getReason() { return reason; }
+}

--- a/backend/Projekatsiit2023/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/enums/CancelerType.java
+++ b/backend/Projekatsiit2023/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/enums/CancelerType.java
@@ -1,0 +1,6 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.enums;
+
+public enum CancelerType {
+    DRIVER,
+    PASSENGER
+}


### PR DESCRIPTION
- Implement ride cancellation endpoint at POST /api/rides/{id}/cancel
- Add validation for cancellation requests based on canceler type
- Add RideCancelRequest and RideCancelResponse DTOs
- Add enum CancelerType (DRIVER, PASSENGER)