### PR TITLE
Fix fragment restoration, drawer menu and login state on rotation

### DIFF
--- a/mobile/TaxiApp/app/src/main/java/com/example/taxiapp/ui/MainActivity.java
+++ b/mobile/TaxiApp/app/src/main/java/com/example/taxiapp/ui/MainActivity.java
@@ -18,9 +18,13 @@ import com.google.android.material.navigation.NavigationView;
 
 public class MainActivity extends AppCompatActivity {
 
+    private static final String KEY_IS_LOGGED_IN = "isLoggedIn";
+    private static final String KEY_CURRENT_FRAGMENT = "currentFragment";
+
     private DrawerLayout drawerLayout;
     private NavigationView navigationView;
     private boolean isLoggedIn = false;
+    private String currentFragmentTag = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,9 +38,16 @@ public class MainActivity extends AppCompatActivity {
                 drawerLayout.openDrawer(GravityCompat.END)
         );
 
+        if (savedInstanceState != null) {
+            isLoggedIn = savedInstanceState.getBoolean(KEY_IS_LOGGED_IN, false);
+            currentFragmentTag = savedInstanceState.getString(KEY_CURRENT_FRAGMENT, null);
+        }
+
         setupMenu();
+
         if (savedInstanceState == null) {
-            loadFragment(new GuestHomeFragment(), false);
+            Fragment startFragment = isLoggedIn ? new DriverHomeFragment() : new GuestHomeFragment();
+            loadFragment(startFragment, false);
         }
     }
 
@@ -52,25 +63,31 @@ public class MainActivity extends AppCompatActivity {
         navigationView.setNavigationItemSelectedListener(item -> {
             int id = item.getItemId();
 
+            Fragment fragmentToLoad = null;
+
             if (id == R.id.nav_estimate) {
-                loadFragment(new EstimateRouteFragment(), true);
+                fragmentToLoad = new EstimateRouteFragment();
 
             } else if (id == R.id.nav_login) {
-                loadFragment(new LoginFragment(), true);
+                fragmentToLoad = new LoginFragment();
 
             } else if (id == R.id.nav_register) {
-                loadFragment(new RegisterFragment(), true);
+                fragmentToLoad = new RegisterFragment();
 
             } else if (id == R.id.nav_home) {
-                loadFragment(new GuestHomeFragment(), true);
+                fragmentToLoad = new GuestHomeFragment();
 
             } else if (id == R.id.nav_ride_history) {
-                loadFragment(new RideHistoryFragment(), true);
+                fragmentToLoad = new RideHistoryFragment();
 
             } else if (id == R.id.nav_logout) {
                 isLoggedIn = false;
                 setupMenu();
-                loadFragment(new GuestHomeFragment(), false);
+                fragmentToLoad = new GuestHomeFragment();
+            }
+
+            if (fragmentToLoad != null) {
+                loadFragment(fragmentToLoad, true);
             }
 
             drawerLayout.closeDrawer(GravityCompat.END);
@@ -85,17 +102,27 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void loadFragment(Fragment fragment, boolean addToBackStack) {
+        currentFragmentTag = fragment.getClass().getSimpleName();
+
         if (addToBackStack) {
             getSupportFragmentManager()
                     .beginTransaction()
-                    .replace(R.id.main_container, fragment)
-                    .addToBackStack(null)
+                    .replace(R.id.main_container, fragment, currentFragmentTag)
+                    .addToBackStack(currentFragmentTag)
                     .commit();
         } else {
             getSupportFragmentManager()
                     .beginTransaction()
-                    .replace(R.id.main_container, fragment)
+                    .replace(R.id.main_container, fragment, currentFragmentTag)
                     .commit();
         }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean(KEY_IS_LOGGED_IN, isLoggedIn);
+        outState.putString(KEY_CURRENT_FRAGMENT, currentFragmentTag);
     }
 }

--- a/mobile/TaxiApp/app/src/main/java/com/example/taxiapp/ui/driver/DriverHomeFragment.java
+++ b/mobile/TaxiApp/app/src/main/java/com/example/taxiapp/ui/driver/DriverHomeFragment.java
@@ -1,6 +1,5 @@
 package com.example.taxiapp.ui.driver;
 
-import android.content.ClipData;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -11,6 +10,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
 import com.example.taxiapp.R;
@@ -21,8 +21,7 @@ public class DriverHomeFragment extends Fragment {
     private boolean isActive = true;
     private MenuItem logoutItem;
 
-    public DriverHomeFragment() {
-    }
+    public DriverHomeFragment() {}
 
     @Nullable
     @Override
@@ -38,10 +37,14 @@ public class DriverHomeFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        if (savedInstanceState == null) {
+        MapFragment mapFragment = (MapFragment) getChildFragmentManager()
+                .findFragmentById(R.id.map_container);
+
+        if (mapFragment == null) {
+            mapFragment = new MapFragment();
             getChildFragmentManager()
                     .beginTransaction()
-                    .replace(R.id.map_container, new MapFragment())
+                    .replace(R.id.map_container, mapFragment)
                     .commit();
         }
 
@@ -65,20 +68,23 @@ public class DriverHomeFragment extends Fragment {
     private void updateStatusButton(Button button) {
         if (isActive) {
             button.setText("Go Inactive");
-            button.setBackgroundTintList(getResources().getColorStateList(R.color.btn_active_red));
-            button.setTextColor(getResources().getColor(android.R.color.white));
+            button.setBackgroundTintList(ContextCompat.getColorStateList(requireContext(), R.color.btn_active_red));
+            button.setTextColor(ContextCompat.getColor(requireContext(), android.R.color.white));
 
-            logoutItem.setEnabled(false);
-            logoutItem.setTitle("Logout (Must go inactive first)");
+            if (logoutItem != null) {
+                logoutItem.setEnabled(false);
+                logoutItem.setTitle("Logout (Must go inactive first)");
+            }
         } else {
             button.setText("Go Active");
-            button.setBackgroundTintList(getResources().getColorStateList(android.R.color.white));
-            button.setTextColor(getResources().getColor(R.color.btn_active_red));
+            button.setBackgroundTintList(ContextCompat.getColorStateList(requireContext(), android.R.color.white));
+            button.setTextColor(ContextCompat.getColor(requireContext(), R.color.btn_active_red));
             button.setBackgroundResource(R.drawable.border_red_btn);
 
-            logoutItem.setEnabled(true);
-            logoutItem.setTitle("Logout");
+            if (logoutItem != null) {
+                logoutItem.setEnabled(true);
+                logoutItem.setTitle("Logout");
+            }
         }
     }
-
 }


### PR DESCRIPTION
- Preserve isLoggedIn status across configuration changes
- Restore currently displayed fragment after screen rotation
- Ensure correct drawer menu (guest vs driver) is shown after rotation
- Use fragment tags to maintain state and prevent duplicate fragment creation
- Minor cleanup in MainActivity loadFragment and setupMenu logic
- Fixed DriverHomeFragment rotation issue and MapFragment initialization