### PR TITLE
Convert distance from meters to kilometers in price calculation

### DIFF
--- a/backend/Projekatsiit2023/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/services/PricingService.java
+++ b/backend/Projekatsiit2023/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/services/PricingService.java
@@ -72,7 +72,8 @@ public class PricingService {
     public double caclulatePriceForRide(Ride ride){
         double distance = ride.getRoute().getEstimatedDistanceMeters();
         double vehiclePrice = getPrices().getPriceForType(ride.getDriver().getVehicle().getType());
+        double distanceInKm = distance / 1000.0;
 
-        return vehiclePrice + distance * 120;
+        return vehiclePrice + distanceInKm * 120;
     }
 }


### PR DESCRIPTION
Properly converts meters to kilometers before applying the rate of 120 per km.